### PR TITLE
Set context from current request to router

### DIFF
--- a/src/SymfonyRouterMiddleware.php
+++ b/src/SymfonyRouterMiddleware.php
@@ -41,6 +41,7 @@ class SymfonyRouterMiddleware implements Middleware
         try {
             $symfonyRequest = (new HttpFoundationFactory())
                 ->createRequest($request);
+            $this->router->getContext()->fromRequest($symfonyRequest);
             $route = $this->router
                 ->matchRequest($symfonyRequest);
         } catch (ResourceNotFoundException $e) {


### PR DESCRIPTION
I've had a POST-only route responding with 405 Method Not Allowed to a POST request. I've found out the cause is that the RequestContext is, by default, initialized with GET method (and other empty-ish 
values). Resetting the context from the actual request prior to matching it seems to help.