### PR TITLE
Optionally pass a custom ResponseFactoryInterface through the constructor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.4",
+        "middlewares/utils": "^3.1",
         "psr/http-server-middleware": "^1.0",
         "symfony/psr-http-message-bridge": "^1.1",
         "symfony/routing": "^5.0"
@@ -24,7 +25,6 @@
         "doctrine/coding-standard": "^7.0",
         "infection/infection": "^0.15",
         "laminas/laminas-diactoros": "^2.3",
-        "middlewares/utils": "^2.1",
         "phpmd/phpmd": "^2.6",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "phpstan/phpstan": "^0.12",
@@ -54,7 +54,6 @@
         "lint": "parallel-lint ./src",
         "phpcbf": "phpcbf",
         "phpcs": "phpcs",
-        "phpmd": "phpmd src text cleancode,codesize,controversial,design,naming,unusedcode",
         "phpstan": "phpstan analyse",
         "phpunit": "phpunit --configuration phpunit.xml.dist",
         "psalm": "psalm",
@@ -62,7 +61,6 @@
             "@lint",
             "@phpunit",
             "@phpcs",
-            "@phpmd",
             "@phpstan",
             "@psalm"
         ]

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,166 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "23ceeed993f47b4ce5b63b5c7b75a918",
+    "content-hash": "00462715cfc4290349de3e60a3105db9",
     "packages": [
+        {
+            "name": "middlewares/utils",
+            "version": "v3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/middlewares/utils.git",
+                "reference": "13689487e8f3bba10b6cc66ed206efc8b874163e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/middlewares/utils/zipball/13689487e8f3bba10b6cc66ed206efc8b874163e",
+                "reference": "13689487e8f3bba10b6cc66ed206efc8b874163e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2",
+                "psr/container": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0",
+                "psr/http-server-middleware": "^1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "guzzlehttp/psr7": "dev-master",
+                "laminas/laminas-diactoros": "^2.2",
+                "nyholm/psr7": "^1.0",
+                "oscarotero/php-cs-fixer-config": "^1.0",
+                "phpunit/phpunit": "^8.1",
+                "slim/psr7": "~0.3",
+                "squizlabs/php_codesniffer": "^3.0",
+                "sunrise/http-message": "^1.0",
+                "sunrise/http-server-request": "^1.0",
+                "sunrise/stream": "^1.0",
+                "sunrise/uri": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Middlewares\\Utils\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Common utils for PSR-15 middleware packages",
+            "homepage": "https://github.com/middlewares/utils",
+            "keywords": [
+                "PSR-11",
+                "http",
+                "middleware",
+                "psr-15",
+                "psr-17",
+                "psr-7"
+            ],
+            "time": "2020-01-19T00:30:41+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2019-04-30T12:38:16+00:00"
+        },
         {
             "name": "psr/http-message",
             "version": "1.0.1",
@@ -1488,57 +1646,6 @@
                 }
             ],
             "time": "2020-05-20T16:45:56+00:00"
-        },
-        {
-            "name": "middlewares/utils",
-            "version": "v2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/middlewares/utils.git",
-                "reference": "7dc49454b4fbf249226023c7b77658b6068abfbc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/middlewares/utils/zipball/7dc49454b4fbf249226023c7b77658b6068abfbc",
-                "reference": "7dc49454b4fbf249226023c7b77658b6068abfbc",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0",
-                "psr/container": "^1.0",
-                "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.0",
-                "psr/http-server-middleware": "^1.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.0",
-                "guzzlehttp/psr7": "^1.3",
-                "phpunit/phpunit": "^6.0|^7.0",
-                "slim/http": "^0.3",
-                "squizlabs/php_codesniffer": "^3.0",
-                "zendframework/zend-diactoros": "^1.3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Middlewares\\Utils\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Common utils to create PSR-15 middleware packages",
-            "homepage": "https://github.com/middlewares/utils",
-            "keywords": [
-                "PSR-11",
-                "http",
-                "middleware",
-                "psr-15",
-                "psr-17",
-                "psr-7"
-            ],
-            "time": "2019-03-05T22:06:37+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -3172,107 +3279,6 @@
             "time": "2020-03-03T09:12:48+00:00"
         },
         {
-            "name": "psr/container",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "time": "2017-02-14T16:28:37+00:00"
-        },
-        {
-            "name": "psr/http-factory",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.0.0",
-                "psr/http-message": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interfaces for PSR-7 HTTP message factories",
-            "keywords": [
-                "factory",
-                "http",
-                "message",
-                "psr",
-                "psr-17",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "time": "2019-04-30T12:38:16+00:00"
-        },
-        {
             "name": "psr/log",
             "version": "1.1.3",
             "source": {
@@ -3956,16 +3962,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.1.1",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "56b3ba194e0cbaaf3de7ccd353c289d7a84ed022"
+                "reference": "86991e2b33446cd96e648c18bcdb1e95afb2c05a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/56b3ba194e0cbaaf3de7ccd353c289d7a84ed022",
-                "reference": "56b3ba194e0cbaaf3de7ccd353c289d7a84ed022",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/86991e2b33446cd96e648c18bcdb1e95afb2c05a",
+                "reference": "86991e2b33446cd96e648c18bcdb1e95afb2c05a",
                 "shasum": ""
             },
             "require": {
@@ -3977,7 +3983,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 }
             },
             "autoload": {
@@ -4004,7 +4010,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-06-26T12:17:54+00:00"
+            "time": "2020-07-05T08:31:53+00:00"
         },
         {
             "name": "sebastian/version",

--- a/src/SymfonyRouterMiddleware.php
+++ b/src/SymfonyRouterMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DelOlmo\Middleware;
 
+use Middlewares\Utils\Factory;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -24,11 +25,12 @@ class SymfonyRouterMiddleware implements Middleware
 
     public function __construct(
         Router $router,
-        ResponseFactoryInterface $responseFactory
+        ?ResponseFactoryInterface $responseFactory = null
     ) {
         $this->router = $router;
 
-        $this->responseFactory = $responseFactory;
+        $this->responseFactory = $responseFactory ??
+            $this->getDefaultResponseFactory();
     }
 
     public function process(Request $request, Handler $handler) : Response
@@ -62,5 +64,10 @@ class SymfonyRouterMiddleware implements Middleware
         }
 
         return $handler->handle($request);
+    }
+
+    private function getDefaultResponseFactory() : ResponseFactoryInterface
+    {
+        return Factory::getResponseFactory();
     }
 }

--- a/tests/SymfonyRouterMiddlewareTest.php
+++ b/tests/SymfonyRouterMiddlewareTest.php
@@ -103,9 +103,7 @@ class SymfonyRouterMiddlewareTest extends TestCase
             ->with($symfonyRequest)
             ->willReturn([]);
 
-        $factory = Factory::getResponseFactory();
-
-        $middleware = new SymfonyRouterMiddleware($router, $factory);
+        $middleware = new SymfonyRouterMiddleware($router);
 
         Dispatcher::run([$middleware], $request);
     }
@@ -129,9 +127,7 @@ class SymfonyRouterMiddlewareTest extends TestCase
 
         $p->setValue($this->router, $matcher);
 
-        $factory = Factory::getResponseFactory();
-
-        $middleware = new SymfonyRouterMiddleware($this->router, $factory);
+        $middleware = new SymfonyRouterMiddleware($this->router);
 
         $response = Dispatcher::run([$middleware], $request);
 
@@ -157,9 +153,7 @@ class SymfonyRouterMiddlewareTest extends TestCase
 
         $p->setValue($this->router, $matcher);
 
-        $factory = Factory::getResponseFactory();
-
-        $middleware = new SymfonyRouterMiddleware($this->router, $factory);
+        $middleware = new SymfonyRouterMiddleware($this->router);
 
         $response = Dispatcher::run([$middleware], $request);
 
@@ -181,9 +175,7 @@ class SymfonyRouterMiddlewareTest extends TestCase
 
         $p->setValue($this->router, $matcher);
 
-        $factory = Factory::getResponseFactory();
-
-        $middleware = new SymfonyRouterMiddleware($this->router, $factory);
+        $middleware = new SymfonyRouterMiddleware($this->router);
 
         $response = Dispatcher::run([$middleware], $request);
 
@@ -209,9 +201,7 @@ class SymfonyRouterMiddlewareTest extends TestCase
 
         $p->setValue($this->router, $matcher);
 
-        $factory = Factory::getResponseFactory();
-
-        $middleware = new SymfonyRouterMiddleware($this->router, $factory);
+        $middleware = new SymfonyRouterMiddleware($this->router);
 
         $dummyFn = static function ($request) : void {
             echo $request->getAttribute('_route');

--- a/tests/SymfonyRouterMiddlewareTest.php
+++ b/tests/SymfonyRouterMiddlewareTest.php
@@ -7,10 +7,12 @@ namespace DelOlmo\Middleware;
 use Middlewares\Utils\Dispatcher;
 use Middlewares\Utils\Factory;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseFactoryInterface;
 use ReflectionProperty;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Routing\Exception\NoConfigurationException;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Routing\Matcher\UrlMatcher;
 use Symfony\Component\Routing\RequestContext;
@@ -33,6 +35,45 @@ class SymfonyRouterMiddlewareTest extends TestCase
 
         $this->routes = new RouteCollection();
         $this->routes->add('test', new Route('/users', [], [], [], '', [], ['GET']));
+    }
+
+    public function testNonDefaultResponseFactory() : void
+    {
+        $factory = $this->createMock(ResponseFactoryInterface::class);
+
+        $factory
+          ->expects(self::once())
+          ->method('createResponse')
+          ->with(404);
+
+        $context = $this->createMock(RequestContext::class);
+
+        $router = $this->createMock(Router::class);
+
+        $router
+            ->expects(self::once())
+            ->method('getContext')
+            ->willReturn($context);
+
+        $request = Factory::createServerRequest('GET', '/');
+
+        $symfonyRequest = (new HttpFoundationFactory())
+            ->createRequest($request);
+
+        $context
+            ->expects(self::once())
+            ->method('fromRequest')
+            ->with($symfonyRequest);
+
+        $router
+            ->expects(self::once())
+            ->method('matchRequest')
+            ->with($symfonyRequest)
+            ->will(self::throwException(new ResourceNotFoundException()));
+
+        $middleware = new SymfonyRouterMiddleware($router, $factory);
+
+        Dispatcher::run([$middleware], $request);
     }
 
     public function testRequestContextBeingUpdated() : void


### PR DESCRIPTION
Update `middlewares\utils` to `^3.0` and allow passing a custom ResponseFactoryInterface through the constructor. The default response factory will be created by the `Middlewares\Utils\Factory` static method `getResponseFactory`, preserving backwards compatibility.